### PR TITLE
Payload issues fix

### DIFF
--- a/src/Sqs/Connector.php
+++ b/src/Sqs/Connector.php
@@ -54,12 +54,17 @@ class Connector extends SqsConnector
     {
         if (! is_array($payload)) $payload = json_decode($payload, true);
 
-        $body = [
-            'job' => $class . '@handle',
-            'data' => json_decode($payload['Body'])
-        ];
+        if(!array_key_exists('job', $payload) || !array_key_exists('data', $payload)){
 
-        $payload['Body'] = json_encode($body);
+          $body = [
+              'job' => $class . '@handle',
+              'data' => json_decode($payload['Body']),
+              'was_plain' => true
+          ];
+
+          $payload['Body'] = json_encode($body);
+
+        }
 
         return $payload;
     }

--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -45,4 +45,21 @@ class Queue extends SqsQueue
             ? Config::get('sqs-plain.handlers')[$queue]
             : Config::get('sqs-plain.default-handler');
     }
+    
+    /**
+     * Push a raw payload onto the queue.
+     *
+     * @param  string  $payload
+     * @param  string  $queue
+     * @param  array   $options
+     * @return mixed
+     */
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        $payload = json_decode($payload, true);
+
+        $response = $this->sqs->sendMessage(['QueueUrl' => $this->getQueue($queue), 'MessageBody' => array_key_exists('was_plain', $payload) ? json_encode($payload['data']) : json_encode($payload)]);
+
+        return $response->get('MessageId');
+    }
 }


### PR DESCRIPTION
Suggested fix to open issue #4 

We were tackling the issue from the wrong angle first, as we were trying to match Laravel's failed job payload format (uses CallQueuedHandler class), but the real issue was payloads were coming from the queue in one format, and would be put back in a different format (modified to `[job, data]` array) if they were retried after failing for example.

The solution was to only modify payloads that don't follow the `[job, data]` format and flag them with `was_plain => true`. By overriding the pushRaw method from the parent class, we can check messages/payloads before pushing them (back) to the queue, and if they include the `was_plain` flag we know we need to bring them back to their original format.

I am open to suggestions, but found this to be a good solution for my team and our use case in particular!

Thanks @dusterio!