### PR TITLE
The signature of the constructor of the parent class has changed to v…

### DIFF
--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -72,7 +72,7 @@ class Queue extends SqsQueue
 
             $response = $this->modifyPayload($response['Messages'][0], $class);
 
-            return new SqsJob($this->container, $this->sqs, $queue, $response);
+            return new SqsJob($this->container, $this->sqs, $response, $this->connectionName, $queue);
         }
     }
 


### PR DESCRIPTION
I got this error when starting up artisan queue:work:

[2017-01-27 14:50:54] lumen.ERROR: exception 'ErrorException' with message 'Argument 3 passed to Illuminate\Queue\Jobs\SqsJob::__construct() must be of the type array, string given, called in /Users/nroberge/www/csdconstruction/services/lumen/vendor/dusterio/laravel-plain-sqs/src/Sqs/Queue.php on line 78 and defined' in /Users/nroberge/www/csdconstruction/services/lumen/vendor/illuminate/queue/Jobs/SqsJob.php:35
Stack trace:
#0 /Users/nroberge/www/csdconstruction/services/lumen/vendor/illuminate/queue/Jobs/SqsJob.php(35): Laravel\Lumen\Application->Laravel\Lumen\Concerns\{closure}(4096, 'Argument 3 pass...', '/Users/nroberge...', 35, Array)

The signature of the constructor of SqsJob wasn't the same as the parent class. 