### PR TITLE
Update to work with laravel 5.8

### DIFF
--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -72,7 +72,7 @@ class Queue extends SqsQueue
 
             $response = $this->modifyPayload($response['Messages'][0], $class);
 
-            if (preg_match('/5\.[4-7]\..*/', $this->container->version())) {
+            if (preg_match('/5\.[4-8]\..*/', $this->container->version())) {
                 return new SqsJob($this->container, $this->sqs, $response, $this->connectionName, $queue);
             }
 


### PR DESCRIPTION
Hi - I'm using this package in a couple of projects.  I updated one of them to Laravel 5.8 recently and started getting the following error: `Argument 3 passed to Illuminate\Queue\Jobs\SqsJob::__construct() must be of the type array, string given, called in /path/to/app/vendor/dusterio/laravel-plain-sqs/src/Sqs/Queue.php on line 79`.  Looking through the code it looks like it might just a version update.  I've made the required change in this pr.