### PR TITLE
Allow requesting specific job attributes

### DIFF
--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -86,7 +86,7 @@ class Queue extends SqsQueue
 
     private function addAttributeNames($options)
     {
-        $list = Config::get('sqs-plain.attributeNames', '');
+        $list = Config::get('sqs-plain.popAttributeNames', '');
         $names = array_merge(['ApproximateReceiveCount'], explode(',', $list));
 
         $options['AttributeNames'] = $this->cleanArray($names);
@@ -96,7 +96,7 @@ class Queue extends SqsQueue
 
     private function addMessageAttributeNames($options)
     {
-        $list = Config::get('sqs-plain.messageAttributeNames', '');
+        $list = Config::get('sqs-plain.popMessageAttributeNames', '');
 
         if (empty($list)) {
             return $options;


### PR DESCRIPTION
We have a use case in which we want to fetch additional attributes of the queued message. This change should allow that through configuration, but maintains the same default behavior.