### PR TITLE
Update support from Laravel 6.0-6.2 to Laravel 6.x

### DIFF
--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -72,7 +72,7 @@ class Queue extends SqsQueue
 
             $response = $this->modifyPayload($response['Messages'][0], $class);
 
-            if (preg_match('/5\.[4-8]\..*|6\.[0-2]\..*/', $this->container->version())) {
+            if (preg_match('/(5\.[4-8]\..*)|(6\.[0-9]*\..*)/', $this->container->version())) {
                 return new SqsJob($this->container, $this->sqs, $response, $this->connectionName, $queue);
             }
 


### PR DESCRIPTION
Laravel 6.5.2 is currently available. Laravel versions are incrementing quickly now that they've moved to Semantic Versioning. 

The composer.json in this library allows 6.x versions, but the regex that checks container version is currently restricted to 6.0-6.2 versions. Updated the regex to support all 6.x container versions (e.g. 6.0.x to 6.10.x and beyond).