### PR TITLE
default behavior for the job if handler is null

### DIFF
--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -70,7 +70,9 @@ class Queue extends SqsQueue
                 ? $this->container['config']->get('sqs-plain.handlers')[$queueId]
                 : $this->container['config']->get('sqs-plain.default-handler');
 
-            $response = $this->modifyPayload($response['Messages'][0], $class);
+            $response = is_null($class) ?
+				$response['Messages'][0] :
+				$this->modifyPayload($response['Messages'][0], $class);
 
             if (preg_match('/(5\.[4-8]\..*)|(6\.[0-9]*\..*)/', $this->container->version())) {
                 return new SqsJob($this->container, $this->sqs, $response, $this->connectionName, $queue);


### PR DESCRIPTION
If handler or default-handler in config is set to null, get the job from queue message, like native laravel