### PR TITLE
Add support for Laravel 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "illuminate/support": "5.*|^6.0",
-	"illuminate/queue": "5.*|^6.0",
-	"illuminate/bus": "5.*|^6.0",
+        "illuminate/support": "5.*|^6.0|^7.0",
+	"illuminate/queue": "5.*|^6.0|^7.0",
+	"illuminate/bus": "5.*|^6.0|^7.0",
 	"aws/aws-sdk-php": "~3.0"
     },
     "require-dev": {

--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -72,7 +72,7 @@ class Queue extends SqsQueue
 
             $response = $this->modifyPayload($response['Messages'][0], $class);
 
-            if (preg_match('/(5\.[4-8]\..*)|(6\.[0-9]*\..*)/', $this->container->version())) {
+            if (preg_match('/(5\.[4-8]\..*)|(6\.[0-9]*\..*)|(7\.[0-9]*\..*)/', $this->container->version())) {
                 return new SqsJob($this->container, $this->sqs, $response, $this->connectionName, $queue);
             }
 


### PR DESCRIPTION
Laravel 7.0.8 is currently available. Laravel versions are incrementing quickly now that the project moved to Semantic Versioning, with plans to release a new major version every 6 months. Perhaps this could support all versions from 5.0 and beyond until a breaking change occurs?

In the meantime, I updated composer.json and the regex that checks container version to support all 7.x container versions.