### PR TITLE
[Bug] Row in failed_jobs not inserting when HandlerJob fails

### DIFF
--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -93,7 +93,8 @@ class Queue extends SqsQueue
 
         $body = [
             'job' => $class . '@handle',
-            'data' => isset($body['data']) ? $body['data'] : $body
+            'data' => isset($body['data']) ? $body['data'] : $body,
+            'uuid' => $payload['MessageId']
         ];
 
         $payload['Body'] = json_encode($body);


### PR DESCRIPTION
Hey,

It looks like if the HandlerJob is failing or throwing an exception for any reason we are not getting the message in the "failed_jobs" table. In the logs we were able to see this error "Undefined index: uuid" which was thrown when laravel was trying to insert the row (in DatabaseUuidFailedJobProvider:58). After a lot of investigation, I find out that the UUID (Sqs message ID) was not in the payload. 

With this PR I added the "uuid" with the value of the message id in the payload which makes everything work properly.

This would be awesome for us if you could merge so we could use your lib ! :)