### PR TITLE
Bumps the Laravel Compatibility to Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,13 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "illuminate/support": "5.*|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/queue": "5.*|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/bus": "5.*|^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/queue": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/bus": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0",
         "aws/aws-sdk-php": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*|^9.5.10",
-        "codeclimate/php-test-reporter": "dev-master"
+        "phpunit/phpunit": "3.7.*|^9.5.10|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Sqs/Queue.php
+++ b/src/Sqs/Queue.php
@@ -72,7 +72,10 @@ class Queue extends SqsQueue
 
             $response = $this->modifyPayload($response['Messages'][0], $class);
 
-            if (preg_match('/(5\.[4-8]\..*)|(6\.[0-9]*\..*)|(7\.[0-9]*\..*)|(8\.[0-9]*\..*)|(9\.[0-9]*\..*)/', $this->container->version())) {
+            if (preg_match(
+                '/(5\.[4-8]\..*)|(6\.[0-9]*\..*)|(7\.[0-9]*\..*)|(8\.[0-9]*\..*)|(9\.[0-9]*\..*)|(10\.[0-9]*\..*)/',
+                $this->container->version())
+            ) {
                 return new SqsJob($this->container, $this->sqs, $response, $this->connectionName, $queue);
             }
 

--- a/tests/PlainSqs/QueueTest.php
+++ b/tests/PlainSqs/QueueTest.php
@@ -1,15 +1,17 @@
 <?php
 
 namespace Dusterio\PlainSqs\Tests;
+
 use Aws\Sqs\SqsClient;
 use Dusterio\PlainSqs\Jobs\DispatcherJob;
 use Dusterio\PlainSqs\Sqs\Queue;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class QueueTest
  * @package Dusterio\PlainSqs\Tests
  */
-class QueueTest extends \PHPUnit_Framework_TestCase
+class QueueTest extends TestCase
 {
     /**
      * @test


### PR DESCRIPTION
Resolves #60

- Bumps the compatibility on `composer`;
- Removes the unused deprecated `codeclimate/php-test-reporter` package;
- Adds version `10` to the regex check on `Queue.php`;