### PR TITLE
Removed the unecessary Job extends and alias from example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ If a third-party application is creating custom-format JSON messages, just add a
 implement a handler class as follows:
 
 ```php
-use Illuminate\Contracts\Queue\Job as LaravelJob;
+use Illuminate\Contracts\Queue\Job;
 
-class HandlerJob extends Job
+class HandlerJob
 {
     protected $data;
 
@@ -150,7 +150,7 @@ class HandlerJob extends Job
      * @param LaravelJob $job
      * @param array $data
      */
-    public function handle(LaravelJob $job, array $data)
+    public function handle(Job $job, array $data)
     {
         // This is incoming JSON payload, already decoded to an array
         var_dump($data);


### PR DESCRIPTION
Removed the extends Job statement and the use alias from the readme example as per the following issue:

https://github.com/dusterio/laravel-plain-sqs/issues/40

https://github.com/dusterio/laravel-plain-sqs/pull/41